### PR TITLE
Made the table responsive for smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,8 @@
             </ul>
 
             <h3>Required Materials</h3>
-            <table border="1">
+            <div class="table-container">
+                <table>
                 <thead>
                     <tr>
                         <th>S.No</th>
@@ -48,37 +49,38 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td>1</td>
-                        <td>Oil Pastel Painting</td>
-                        <td>Oil Pastels</td>
-                        <td>Crayon or Wax Colors (blend with pressure)</td>
+                        <td data-label="S.No">1</td>
+                        <td data-label="Art">Oil Pastel Painting</td>
+                        <td data-label="Material">Oil Pastels</td>
+                        <td data-label="Alternative">Crayon or Wax Colors (blend with pressure)</td>
                     </tr>
                     <tr>
-                        <td>2</td>
-                        <td>Watercolor Painting</td>
-                        <td>Watercolor</td>
-                        <td>Affordable, easily available</td>
+                        <td data-label="S.No">2</td>
+                        <td data-label="Art">Watercolor Painting</td>
+                        <td data-label="Material">Watercolor</td>
+                        <td data-label="Alternative">Affordable, easily available</td>
                     </tr>
                     <tr>
-                        <td>3</td>
-                        <td>Pencil Shading</td>
-                        <td>Shading Pencils</td>
-                        <td>Simple HB Pencil</td>
+                        <td data-label="S.No">3</td>
+                        <td data-label="Art">Pencil Shading</td>
+                        <td data-label="Material">Shading Pencils</td>
+                        <td data-label="Alternative">Simple HB Pencil</td>
                     </tr>
                     <tr>
-                        <td>4</td>
-                        <td>Mandala</td>
-                        <td>Pilot Black Pen</td>
-                        <td>Simple Ballpoint or Gel Pen</td>
+                        <td data-label="S.No">4</td>
+                        <td data-label="Art">Mandala</td>
+                        <td data-label="Material">Pilot Black Pen</td>
+                        <td data-label="Alternative">Simple Ballpoint or Gel Pen</td>
                     </tr>
                     <tr>
-                        <td>5</td>
-                        <td>Doodle</td>
-                        <td>Pilot Black Pen</td>
-                        <td>Simple Ballpoint or Gel Pen</td>
+                        <td data-label="S.No">5</td>
+                        <td data-label="Art">Doodle</td>
+                        <td data-label="Material">Pilot Black Pen</td>
+                        <td data-label="Alternative">Simple Ballpoint or Gel Pen</td>
                     </tr>
                 </tbody>
             </table>
+            </div>
 
             <p>Learn any of these art styles on <a href="https://www.youtube.com/results?search_query=jiya_the_coolartist" target="_blank">YouTube (my little artist)</a></p>
 

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@
 
 /* Animated Gradient Background */
 body {
+    overflow-x: hidden;
     min-height: 100vh;
     background: linear-gradient(-45deg, #fbc2eb, #a6c1ee, #fddb92, #d4fc79);
     background-size: 400% 400%;
@@ -94,6 +95,7 @@ table {
     margin-top: 15px;
     overflow: hidden;
     border-radius: 15px;
+    min-width: 600px; /* prevents squeezing too much */
 }
 
 table th {
@@ -109,6 +111,12 @@ table td {
 
 table tr:nth-child(even) {
     background: rgba(255,255,255,0.5);
+}
+
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 /* Art Cards */
@@ -237,3 +245,35 @@ body{
     100% { transform: translate(-50%, -50%) rotate(360deg); }
 }
 
+@media (max-width: 600px) {
+
+    table thead {
+        display: none;
+    }
+
+    table, table tbody, table tr, table td {
+        display: block;
+        width: 100%;
+    }
+
+    table tr {
+        margin-bottom: 15px;
+        background: rgba(255,255,255,0.6);
+        border-radius: 12px;
+        padding: 10px;
+    }
+
+    table td {
+        text-align: left;
+        padding: 8px 10px;
+        position: relative;
+    }
+
+    table td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        display: block;
+        margin-bottom: 4px;
+        color: #ff4081;
+    }
+}


### PR DESCRIPTION
## Fix responsive layout issue in the Required Materials table.
Wrapped table inside a .table-container with overflow-x: auto
Prevented full-page horizontal scrolling
Improved mobile and tablet responsiveness
Ensured table scrolls within its container on smaller screens
Enhanced readability and overall user experience
This update resolves layout breakage and improves accessibility across all screen sizes.

Closes #7

## Screenshot:-

<img width="480" height="376" alt="image" src="https://github.com/user-attachments/assets/24dc2ffb-6071-4d10-b5b0-5bff78aa54e1" />
<img width="456" height="380" alt="image" src="https://github.com/user-attachments/assets/42376f06-af31-4c20-becb-9908e50e2dec" />
<img width="485" height="379" alt="image" src="https://github.com/user-attachments/assets/c33d42a3-d87d-4119-bac0-2aeb293db44a" />
<img width="449" height="377" alt="image" src="https://github.com/user-attachments/assets/fe7770b8-262e-4ff1-8be4-3f49d16020e7" />
