### PR TITLE
Fix : Excessive gap between navbar and sections(issue #32)

### DIFF
--- a/style.css
+++ b/style.css
@@ -405,10 +405,10 @@ body {
 .hero {
   display: grid;
   place-items: center;
-  min-height: 60vh;
+  min-height: 15vh;
   font-family: 'Dancing Script', cursive;
   font-size: 1.8rem;
-  color: rgba(140, 90, 200, 0.2);
+  color: rgba(140, 90, 200, 0.4);
   padding: 40px 20px;
 }
 


### PR DESCRIPTION
## Description
Fixes Issue #32 - Reduces excessive gap between navbar and first section

## Changes
- Reduced `.hero` min-height from 60vh to 15vh
- Improved hero text visibility by increasing opacity

## Testing
- Tested on desktop, tablet, and mobile viewports
- No overlapping or layout issues
- Visual continuity achieved between navbar and content sections
- 
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/38d2e6d7-9458-444e-94dd-912279e54a81" />

### Closes #32 