### PR TITLE
fix: Text Visibility Issue in Dark Theme on Contact Page

### DIFF
--- a/css/contactStyle.css
+++ b/css/contactStyle.css
@@ -60,7 +60,7 @@ body{
 }
 
 .subtitle{
-    color:#333;
+    color:var(--text-primary);
     font-weight:500;
     margin-bottom:30px;
     opacity:0.85;
@@ -97,7 +97,7 @@ body{
 /* Response text */
 .response-time{
     margin-top:15px;
-    color:#333;
+    color:var(--text-primary);
     font-weight:500;
     opacity:0.8;
 }


### PR DESCRIPTION

**Changes made:**
- Updated `.response-time` color from hardcoded `#333` → `var(--text-primary)` 
- Updated `.subtitle` color from hardcoded `#333` → `var(--text-primary)`

**How this fixes the issue:**
The site uses a CSS variable system that automatically adapts to dark theme:
- **Light theme:** `--text-primary` = `#333333` (dark gray)
- **Dark theme:** `--text-primary` = `#ebe4f8` (light gray)

Now "I usually reply within 24hr" and the subtitle text will have proper contrast in both light and dark modes, improving readability and accessibility. No more text blending into the dark background!

Screenshot

<img width="632" height="206" alt="Screenshot 2026-03-22 120912" src="https://github.com/user-attachments/assets/3fc0d0bf-bbb7-49df-8260-068f1161927f" />


closes #72